### PR TITLE
updated unzip version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lodash.map": "^4.6.0",
     "machine": "^10.3.1",
     "machinepack-fs": "^2.1.0",
-    "unzip2": "^0.2.5"
+    "unzip2": "https://github.com/glebdmitriew/node-unzip-2.git"
   },
   "devDependencies": {
     "test-machinepack-mocha": "^2.1.1"


### PR DESCRIPTION
I changed the installation/update source of the unzip2 package which is a dependency of it from the official repository, since in npm there is an older version that conflicts with the grateful dependency and its version with higher versions of node (=< 14)